### PR TITLE
Fix offset for shaders in Skia backend

### DIFF
--- a/bl_bench/backend_skia.cpp
+++ b/bl_bench/backend_skia.cpp
@@ -523,7 +523,7 @@ void SkiaModule::renderShape(RenderOp op, ShapeData shape) {
       p.setColor(_rndColor.nextRgba32().value);
     }
     else {
-      BLRect rect(base.x, base.y, wh, wh);
+      BLRect rect(0, 0, wh, wh);
       p.setShader(createShader(style, rect));
     }
 


### PR DESCRIPTION
We already apply a translation to the canvas, so we were essentially applying the offset twice. Example:

Blend2D image:
<img width="916" alt="image" src="https://github.com/user-attachments/assets/787319b5-1a03-4200-bb88-79581d8e734c" />

Skia image before:
<img width="917" alt="image" src="https://github.com/user-attachments/assets/d8e4c2cc-7c26-4a0b-858d-3e3ed17b9975" />

Skia image after:
<img width="917" alt="image" src="https://github.com/user-attachments/assets/cde0a69b-92e2-4226-b59e-b67df177819d" />

The gradient still looks different (haven't looked into what's going on there), but at least the position is correct now.